### PR TITLE
Fixes for wattpad2epub.py

### DIFF
--- a/wattpad2epub.py
+++ b/wattpad2epub.py
@@ -156,7 +156,8 @@ def get_chapter(url, i):
         text.append('</div>\n')
     chapter = epub.EpubHtml(title=chaptertitle, file_name=chapterfile,
                             lang='en')
-    chapter.content = clean_text("".join(text))
+    chapter_header = f"<h2>{chaptertitle}</h2>"
+    chapter.content = chapter_header + clean_text("".join(text))
     return chapter
 
 


### PR DESCRIPTION
- Update CSS selectors to match current Wattpad layout
- Switch chapter filename to generic number-based index to prevent issues with unusual characters in titles
- Add text cleaning back